### PR TITLE
feat: add support for v3 model

### DIFF
--- a/chunked_pooling/__init__.py
+++ b/chunked_pooling/__init__.py
@@ -49,7 +49,7 @@ def chunked_pooling(
             if (end - start) >= 1
         ]
         pooled_embeddings = [
-            embedding.detach().cpu().numpy() for embedding in pooled_embeddings
+            embedding.float().detach().cpu().numpy() for embedding in pooled_embeddings
         ]
         outputs.append(pooled_embeddings)
 

--- a/chunked_pooling/mteb_chunked_eval.py
+++ b/chunked_pooling/mteb_chunked_eval.py
@@ -23,19 +23,24 @@ class AbsTaskChunkedRetrieval(AbsTask):
         prune_size: Optional[int] = None,
         chunk_size: Optional[int] = None,
         n_sentences: Optional[int] = None,
+        model_has_instructions: bool = False,
         **kwargs,
     ):
         super().__init__(**kwargs)
-        self.retrieval_task = getattr(
-            Retrieval,
-            self.metadata_dict['dataset'].get('name', None)
-            or self.metadata_dict.get('name'),
-        )()
+        try:
+            self.retrieval_task = getattr(
+                Retrieval,
+                self.metadata_dict['dataset'].get('name', None)
+                or self.metadata_dict.get('name'),
+            )()
+        except:
+            logger.warning('Could not initialize retrieval_task')
         self.chunking_strategy = chunking_strategy
         self.chunker = Chunker(self.chunking_strategy)
         self.chunked_pooling_enabled = chunked_pooling_enabled
         self.tokenizer = tokenizer
         self.prune_size = prune_size
+        self.model_has_instructions = model_has_instructions
         self.chunking_args = {
             'chunk_size': chunk_size,
             'n_sentences': n_sentences,
@@ -97,7 +102,7 @@ class AbsTaskChunkedRetrieval(AbsTask):
         else:
             query_ids = list(queries.keys())
             query_texts = [queries[k] for k in query_ids]
-            query_embs = model.encode(query_texts)
+            query_embs = model.encode_queries(query_texts)
 
             corpus_ids = list(corpus.keys())
             corpus_texts = [
@@ -109,17 +114,7 @@ class AbsTaskChunkedRetrieval(AbsTask):
                 for k in corpus_ids
             ]
 
-            chunk_annotations = [
-                self._extend_special_tokens(
-                    self.chunker.chunk(
-                        text,
-                        self.tokenizer,
-                        chunking_strategy=self.chunking_strategy,
-                        **self.chunking_args,
-                    )
-                )
-                for text in corpus_texts
-            ]
+            chunk_annotations = self._calculate_annotations(model, corpus_texts)
 
             corpus_embs = []
             with torch.no_grad():
@@ -130,7 +125,8 @@ class AbsTaskChunkedRetrieval(AbsTask):
                     ),
                     total=(len(corpus_texts) // batch_size),
                 ):
-                    text_inputs = [x[0] for x in inputs]
+                    instr = model.get_instructions()[1]
+                    text_inputs = [instr + x[0] for x in inputs]
                     annotations = [x[1] for x in inputs]
                     model_inputs = self.tokenizer(
                         text_inputs,
@@ -255,6 +251,27 @@ class AbsTaskChunkedRetrieval(AbsTask):
             chunked_corpus[k] = current_doc
         return chunked_corpus
 
+    def _calculate_annotations(self, model, corpus_texts):
+        if self.model_has_instructions:
+            instr = model.get_instructions()[1]
+            instr_tokens = self.tokenizer(instr, add_special_tokens=False)
+            n_instruction_tokens = len(instr_tokens[0])
+        else:
+            n_instruction_tokens = 0
+        chunk_annotations = [
+            self._extend_special_tokens(
+                self.chunker.chunk(
+                    text,
+                    self.tokenizer,
+                    chunking_strategy=self.chunking_strategy,
+                    **self.chunking_args,
+                ),
+                n_instruction_tokens=n_instruction_tokens,
+            )
+            for text in corpus_texts
+        ]
+        return chunk_annotations
+
     @staticmethod
     def _flatten_chunks(chunked_corpus):
         flattened_corpus = dict()
@@ -274,16 +291,26 @@ class AbsTaskChunkedRetrieval(AbsTask):
             yield li[i : i + batch_size]
 
     @staticmethod
-    def _extend_special_tokens(annotations):
+    def _extend_special_tokens(
+        annotations, n_instruction_tokens=0, include_prefix=True, include_sep=True
+    ):
         """Extends the spans because of additional special tokens, e.g. the CLS token
         which are not considered by the chunker.
         """
         new_annotations = []
         for i in range(len(annotations)):
-            left = annotations[i][0] + int(i > 0)  # move everything by one for [CLS]
+            add_left_offset = 1 if (not include_prefix) or int(i > 0) else 0
+            left_offset = 1 + n_instruction_tokens
+            left = (
+                annotations[i][0] + add_left_offset * left_offset
+            )  # move everything by one for [CLS]
+
+            add_sep = 1 if include_sep and ((i + 1) == len(annotations)) else 0
+            right_offset = left_offset + add_sep
             right = (
-                annotations[i][1] + 1 + int((i + 1) == len(annotations))
+                annotations[i][1] + right_offset
             )  # move everything by one for [CLS] and the last one for [SEP]
+
             new_annotations.append((left, right))
         return new_annotations
 

--- a/chunked_pooling/wrappers.py
+++ b/chunked_pooling/wrappers.py
@@ -6,9 +6,13 @@ from typing import List, Union, Optional
 
 
 class JinaEmbeddingsV3Wrapper(nn.Module):
-    def __init__(self, model_name, tasks=['retrieval.query', 'retrieval.passage']):
+    def __init__(
+        self, model_name, tasks=['retrieval.query', 'retrieval.passage'], **model_kwargs
+    ):
         super().__init__()
-        self._model = AutoModel.from_pretrained(model_name, trust_remote_code=True)
+        self._model = AutoModel.from_pretrained(
+            model_name, trust_remote_code=True, **model_kwargs
+        )
         self.tasks = tasks
 
     def encode_queries(
@@ -75,9 +79,9 @@ def remove_unsupported_kwargs(original_encode):
     return wrapper
 
 
-def load_model(model_name):
+def load_model(model_name, **model_kwargs):
     if model_name in MODEL_WRAPPERS:
-        model = MODEL_WRAPPERS[model_name](model_name)
+        model = MODEL_WRAPPERS[model_name](model_name, **model_kwargs)
         has_instructions = MODEL_WRAPPERS[model_name].has_instructions()
     else:
         model = AutoModel.from_pretrained(model_name, trust_remote_code=True)

--- a/chunked_pooling/wrappers.py
+++ b/chunked_pooling/wrappers.py
@@ -1,0 +1,60 @@
+import torch
+import torch.nn as nn
+from transformers import AutoModel
+
+from typing import List, Union, Optional
+
+
+class JinaEmbeddingsV3Wrapper(nn.Module):
+    def __init__(self, model_name, tasks=['retrieval.query', 'retrieval.passage']):
+        super().__init__()
+        self._model = AutoModel.from_pretrained(model_name, trust_remote_code=True)
+        self.tasks = tasks
+
+    def encode_queries(
+        self,
+        sentences: Union[str, List[str]],
+        *args,
+        task: Optional[str] = None,
+        **kwargs,
+    ):
+        return self._model.encode(sentences, *args, task=self.tasks[0], **kwargs)
+
+    def encode_corpus(
+        self,
+        sentences: Union[str, List[str]],
+        *args,
+        **kwargs,
+    ):
+        _sentences = [self._construct_document(sentence) for sentence in sentences]
+        return self._model.encode(_sentences, *args, task=self.tasks[1], **kwargs)
+
+    def get_instructions(self):
+        return [self._model._task_instructions[x] for x in self.tasks]
+
+    def forward(self, *args, **kwargs):
+        task_id = self._model._adaptation_map[self.tasks[1]]
+        num_examples = kwargs['input_ids'].shape[0]
+        adapter_mask = torch.full(
+            (num_examples,), task_id, dtype=torch.int32, device=self._model.device
+        )
+        return self._model.forward(*args, adapter_mask=adapter_mask, **kwargs)
+
+    def _construct_document(self, doc):
+        if isinstance(doc, str):
+            return doc
+        elif 'title' in doc:
+            return f'{doc["title"]} {doc["text"].strip()}'
+        else:
+            return doc['text'].strip()
+
+    @property
+    def device(self):
+        return self._model.device
+
+    @staticmethod
+    def has_instructions():
+        return True
+
+
+MODEL_WRAPPERS = {'jinaai/jina-embeddings-v3': JinaEmbeddingsV3Wrapper}

--- a/run_chunked_eval.py
+++ b/run_chunked_eval.py
@@ -13,9 +13,21 @@ from chunked_pooling.chunked_eval_tasks import (
     LEMBWikimQARetrievalChunked,
 )
 
+from chunked_pooling.wrappers import MODEL_WRAPPERS
+
 DEFAULT_CHUNKING_STRATEGY = 'fixed'
 DEFAULT_CHUNK_SIZE = 256
 DEFAULT_N_SENTENCES = 5
+
+
+def load_model(model_name):
+    if model_name in MODEL_WRAPPERS:
+        return (
+            MODEL_WRAPPERS[model_name](model_name),
+            MODEL_WRAPPERS[model_name].has_instructions(),
+        )
+    else:
+        return AutoModel.from_pretrained(model_name, trust_remote_code=True), False
 
 
 @click.command()
@@ -38,13 +50,14 @@ def main(model_name, strategy, task_name):
     except:
         raise ValueError(f'Unknown task name: {task_name}')
 
-    model = AutoModel.from_pretrained(model_name, trust_remote_code=True)
+    model, has_instructions = load_model(model_name)
     tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
 
     chunking_args = {
         'chunk_size': DEFAULT_CHUNK_SIZE,
         'n_sentences': DEFAULT_N_SENTENCES,
         'chunking_strategy': strategy,
+        'model_has_instructions': has_instructions,
     }
 
     if torch.cuda.is_available():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,48 @@
+import pytest
+
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+from chunked_pooling.mteb_chunked_eval import AbsTaskChunkedRetrieval
+
+
+class DummyTask(AbsTaskChunkedRetrieval):
+    metadata = TaskMetadata(
+        dataset={
+            'path': '~',
+            'revision': '',
+        },
+        name='dummy',
+        description='',
+        type='Retrieval',
+        category='s2p',
+        reference=None,
+        eval_splits=[],
+        eval_langs=[],
+        main_score='ndcg_at_10',
+        date=None,
+        form=None,
+        domains=None,
+        task_subtypes=None,
+        license=None,
+        socioeconomic_status=None,
+        annotations_creators=None,
+        dialect=None,
+        text_creation=None,
+        bibtex_citation=None,
+        n_samples=None,
+        avg_character_length=None,
+    )
+
+    def load_data():
+        pass
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+@pytest.fixture()
+def dummy_task_factory():
+    def _create_dummy_task(*args, **kwargs):
+        return DummyTask(*args, **kwargs)
+
+    return _create_dummy_task

--- a/tests/test_v3.py
+++ b/tests/test_v3.py
@@ -1,0 +1,22 @@
+from transformers import AutoTokenizer
+
+from run_chunked_eval import load_model, DEFAULT_CHUNK_SIZE
+
+MODEL_NAME = 'jinaai/jina-embeddings-v3'
+
+
+def test_instruction_handling(dummy_task_factory):
+    model, has_instructions = load_model(MODEL_NAME)
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME, trust_remote_code=True)
+    task = dummy_task_factory(
+        chunking_strategy='fixed',
+        chunk_size=DEFAULT_CHUNK_SIZE,
+        tokenizer=tokenizer,
+        model_has_instructions=has_instructions,
+    )
+    n_instruction_tokens = len(
+        tokenizer(model.get_instructions()[1], add_special_tokens=False)['input_ids']
+    )
+    annotations_one_token = task._calculate_annotations(model, ['A'])[0]
+    assert len(annotations_one_token) == 1
+    assert annotations_one_token[0] == (0, n_instruction_tokens + 3)


### PR DESCRIPTION
This PR adds support for jina-embeddings-v3. Therefore, it adds:
- a wrapper module with wrapper classes to adjust models to support the  interfaces used by `AbsTaskChunkedRetrieval` 
- adjust the late chunking to handle instructions as jina-embeddings-v3 uses instructions for its retrieval task types.

Evaluation Results on SciFact:

late chunking with instructions (currently used): 73.18
late chunking without instruction: 73.37
normal chunking (instruction append to every chunk): 71.81
without chunking: 72.31