### PR TITLE
feat: add semantic chunking to eval script; add wrapper for minilm

### DIFF
--- a/chunked_pooling/chunking.py
+++ b/chunked_pooling/chunking.py
@@ -31,6 +31,7 @@ class Chunker:
         self.embed_model = HuggingFaceEmbedding(
             model_name=self.embedding_model_name,
             trust_remote_code=True,
+            embed_batch_size=1,
         )
         self.splitter = SemanticSplitterNodeParser(
             embed_model=self.embed_model,
@@ -71,13 +72,12 @@ class Chunker:
             start_chunk_index = bisect.bisect_left(
                 [offset[0] for offset in token_offsets], char_start
             )
-            end_chunk_index = (
-                bisect.bisect_right([offset[1] for offset in token_offsets], char_end)
-                - 1
+            end_chunk_index = bisect.bisect_right(
+                [offset[1] for offset in token_offsets], char_end
             )
 
             # Add the chunk span if it's within the tokenized text
-            if start_chunk_index < len(token_offsets) and end_chunk_index < len(
+            if start_chunk_index < len(token_offsets) and end_chunk_index <= len(
                 token_offsets
             ):
                 chunk_spans.append((start_chunk_index, end_chunk_index))

--- a/chunked_pooling/mteb_chunked_eval.py
+++ b/chunked_pooling/mteb_chunked_eval.py
@@ -25,6 +25,7 @@ class AbsTaskChunkedRetrieval(AbsTask):
         chunk_size: Optional[int] = None,
         n_sentences: Optional[int] = None,
         model_has_instructions: bool = False,
+        embedding_model_name: Optional[str] = None,  # for semantic chunking
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -45,6 +46,7 @@ class AbsTaskChunkedRetrieval(AbsTask):
         self.chunking_args = {
             'chunk_size': chunk_size,
             'n_sentences': n_sentences,
+            'embedding_model_name': embedding_model_name,
         }
 
     def load_data(self, **kwargs):

--- a/chunked_pooling/wrappers.py
+++ b/chunked_pooling/wrappers.py
@@ -2,6 +2,7 @@ from typing import List, Optional, Union
 
 import torch
 import torch.nn as nn
+from sentence_transformers import SentenceTransformer
 from transformers import AutoModel
 
 
@@ -61,7 +62,10 @@ class JinaEmbeddingsV3Wrapper(nn.Module):
         return True
 
 
-MODEL_WRAPPERS = {'jinaai/jina-embeddings-v3': JinaEmbeddingsV3Wrapper}
+MODEL_WRAPPERS = {
+    'jinaai/jina-embeddings-v3': JinaEmbeddingsV3Wrapper,
+    'sentence-transformers/all-MiniLM-L6-v2': SentenceTransformer,
+}
 MODELS_WITHOUT_PROMPT_NAME_ARG = [
     'jinaai/jina-embeddings-v2-small-en',
     'jinaai/jina-embeddings-v2-base-en',
@@ -82,7 +86,10 @@ def remove_unsupported_kwargs(original_encode):
 def load_model(model_name, **model_kwargs):
     if model_name in MODEL_WRAPPERS:
         model = MODEL_WRAPPERS[model_name](model_name, **model_kwargs)
-        has_instructions = MODEL_WRAPPERS[model_name].has_instructions()
+        if hasattr(MODEL_WRAPPERS[model_name], 'has_instructions'):
+            has_instructions = MODEL_WRAPPERS[model_name].has_instructions()
+        else:
+            has_instructions = False
     else:
         model = AutoModel.from_pretrained(model_name, trust_remote_code=True)
         has_instructions = False

--- a/run_chunked_eval.py
+++ b/run_chunked_eval.py
@@ -44,6 +44,7 @@ def main(model_name, strategy, task_name, eval_split):
         'n_sentences': DEFAULT_N_SENTENCES,
         'chunking_strategy': strategy,
         'model_has_instructions': has_instructions,
+        'embedding_model_name': model_name,
     }
 
     if torch.cuda.is_available():

--- a/run_chunked_eval.py
+++ b/run_chunked_eval.py
@@ -29,7 +29,13 @@ BATCH_SIZE = 1
 @click.option(
     '--eval-split', default='test', help='The name of the evaluation split in the task.'
 )
-def main(model_name, strategy, task_name, eval_split):
+@click.option(
+    '--chunking-model',
+    default=None,
+    required=False,
+    help='The name of the model used for semantic chunking.',
+)
+def main(model_name, strategy, task_name, eval_split, chunking_model):
     try:
         task_cls = globals()[task_name]
     except:
@@ -44,7 +50,7 @@ def main(model_name, strategy, task_name, eval_split):
         'n_sentences': DEFAULT_N_SENTENCES,
         'chunking_strategy': strategy,
         'model_has_instructions': has_instructions,
-        'embedding_model_name': model_name,
+        'embedding_model_name': chunking_model if chunking_model else model_name,
     }
 
     if torch.cuda.is_available():

--- a/tests/test_chunking_methods.py
+++ b/tests/test_chunking_methods.py
@@ -98,9 +98,13 @@ def test_chunk_by_tokens():
         assert end - start <= 10
 
 
-def test_chunk_semantically():
+@pytest.mark.parametrize(
+    'model_name',
+    ['jinaai/jina-embeddings-v2-small-en', 'sentence-transformers/all-MiniLM-L6-v2'],
+)
+def test_chunk_semantically(model_name):
     chunker = Chunker(chunking_strategy="semantic")
-    tokenizer = AutoTokenizer.from_pretrained('jinaai/jina-embeddings-v2-small-en')
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
     tokens = tokenizer.encode_plus(
         EXAMPLE_TEXT_1, add_special_tokens=False, return_offsets_mapping=True
     )
@@ -108,7 +112,7 @@ def test_chunk_semantically():
         EXAMPLE_TEXT_1,
         tokenizer=tokenizer,
         chunking_strategy='semantic',
-        embedding_model_name='jinaai/jina-embeddings-v2-small-en',
+        embedding_model_name=model_name,
     )
 
     # check if it returns boundary cues


### PR DESCRIPTION
- Adds the embedding model arguments to make it possible to execute semantic chunking
- Adds SentenceTransformers wrapper to execute MiniLM
- The current semantic chunking implementation omits the punctuation signs in the chunking. This PR changes it to include them
- Makes the semantic chunking test more comprehensive